### PR TITLE
fixed map loading problem

### DIFF
--- a/demo/config/amcl_params.yaml
+++ b/demo/config/amcl_params.yaml
@@ -26,7 +26,7 @@ amcl:
     recovery_alpha_fast: 0.0
     recovery_alpha_slow: 0.0
     resample_interval: 1
-    robot_model_type: "differential"
+    robot_model_type: "nav2_amcl::DifferentialMotionModel"
     save_pose_rate: 0.5
     sigma_hit: 0.2
     tf_broadcast: true


### PR DESCRIPTION
Because of this problem navigation stack on `humble` didn't load a map.
```
[amcl-2] [ERROR] [1660650646.049681332] []: Original error: According to the loaded plugin descriptions the class differential with base class type nav2_amcl::MotionModel does not exist. Declared types are  nav2_amcl::DifferentialMotionModel nav2_amcl::OmniMotionModel
```