### PR TITLE
Fix amcl crashing using galactic images

### DIFF
--- a/demo/config/amcl_params.yaml
+++ b/demo/config/amcl_params.yaml
@@ -26,7 +26,7 @@ amcl:
     recovery_alpha_fast: 0.0
     recovery_alpha_slow: 0.0
     resample_interval: 1
-    robot_model_type: "nav2_amcl::DifferentialMotionModel"
+    robot_model_type: "differential" # on humble this parameter should be changed to nav2_amcl::DifferentialMotionModel
     save_pose_rate: 0.5
     sigma_hit: 0.2
     tf_broadcast: true
@@ -56,6 +56,5 @@ amcl_rclcpp_node:
 
 map_server:
   ros__parameters:
-    use_sim_time: False  
+    use_sim_time: False
     yaml_filename: "map.yaml"
-


### PR DESCRIPTION
`nav2_amcl::DifferentialMotionModel` is used in humble and doesn't work on galactic causing AMCL crash.